### PR TITLE
Changed Console Output Encoding to Unicode

### DIFF
--- a/src/Shinoa/Shinoa.cs
+++ b/src/Shinoa/Shinoa.cs
@@ -63,6 +63,8 @@ namespace Shinoa
             else
                 configurationFileStream = new FileStream("config.yaml", FileMode.Open);
 
+            Console.OutputEncoding = System.Text.Encoding.Unicode;
+
             using (var streamReader = new StreamReader(configurationFileStream))
             {
                 var deserializer = new YamlDotNet.Serialization.Deserializer();


### PR DESCRIPTION
Otherwise the console defaults to the computer's default codepage, which
could be detrimental to the log.